### PR TITLE
Fix: Remove leading spaces from options_dict values

### DIFF
--- a/snortparser.py
+++ b/snortparser.py
@@ -401,7 +401,7 @@ class Parser(object):
                 option = option_string.split(":", 1)
                 key, value = option
                 if key != "pcre":
-                    value = value.split(",")
+                    value = [self.remove_leading_spaces(x) for x in value.split(",")]
                 options_dict[index] = (key, value)
             else:
                 options_dict[index] = (option_string, "")


### PR DESCRIPTION
Remove leading whitespaces from the values of `options_dict`.

**Note**: The Jupyter Notebook _example.ipynb_ will be outdated if the commit is merged. Feel free to rerun the playbook with your environment and commit its output.

### Demonstration

The following example uses the first rule from the Jupyter Notebook _example.ipynb_:

`alert tcp any any -> any any (msg:"Non-Std TCP Client Traffic contains "HX1|3a|" "HX2|3a|" "HX3|3a|" "HX4|3a|" (PLUGX Variant)"; sid:7238331; rev:20170428; flow:established,to_server; content:"Accept|3a 20 2a 2f 2a|"; nocase; content:"HX1|3a|"; distance:0; within:6; fast_pattern; content:"HX2|3a|"; nocase; distance:0; content:"HX3|3a|"; nocase; distance:0; content:"HX4|3a|"; nocase; distance:0; classtype:nonstd-tcp; threshold:type limit, track by_src, count 1 , seconds 60;priority:X; reference:url,cti.cert.europa.eu/index.php/mnuthreatobject/indicatorslist/details/83/12844; gid:1;)`

Before this PR, the parser left some extra whitespace when parsing options with multiple values (see index 20 "threshold" for _options_ OrderedDict):

```
{'header': OrderedDict([('action', 'alert'),
                        ('proto', 'tcp'),
                        ('source', (True, 'any')),
                        ('src_port', (True, 'any')),
                        ('arrow', '->'),
                        ('destination', (True, 'any')),
                        ('dst_port', (True, 'any'))]),
 'options': OrderedDict([(0,
                          ('msg',
                           ['"Non-Std TCP Client Traffic contains "HX1|3a|" '
                            '"HX2|3a|" "HX3|3a|" "HX4|3a|" (PLUGX Variant)"'])),
                         (1, ('sid', ['7238331'])),
                         (2, ('rev', ['20170428'])),
                         (3, ('flow', ['established', 'to_server'])),
                         (4, ('content', ['"Accept|3a 20 2a 2f 2a|"'])),
                         (5, ('nocase', '')),
                         (6, ('content', ['"HX1|3a|"'])),
                         (7, ('distance', ['0'])),
                         (8, ('within', ['6'])),
                         (9, ('fast_pattern', '')),
                         (10, ('content', ['"HX2|3a|"'])),
                         (11, ('nocase', '')),
                         (12, ('distance', ['0'])),
                         (13, ('content', ['"HX3|3a|"'])),
                         (14, ('nocase', '')),
                         (15, ('distance', ['0'])),
                         (16, ('content', ['"HX4|3a|"'])),
                         (17, ('nocase', '')),
                         (18, ('distance', ['0'])),
                         (19, ('classtype', ['nonstd-tcp'])),
                         (20,
                          ('threshold',
                           ['type limit',
                            ' track by_src',
                            ' count 1 ',
                            ' seconds 60'])),
                         (21, ('priority', ['X'])),
                         (22,
                          ('reference',
                           ['url',
                            'cti.cert.europa.eu/index.php/mnuthreatobject/indicatorslist/details/83/12844'])),
                         (23, ('gid', ['1']))])}
```

The commit makes it so that the extra whitespace is stripped from the options with multiple values.

```
{'header': OrderedDict([('action', 'alert'),
                        ('proto', 'tcp'),
                        ('source', (True, 'any')),
                        ('src_port', (True, 'any')),
                        ('arrow', '->'),
                        ('destination', (True, 'any')),
                        ('dst_port', (True, 'any'))]),
 'options': OrderedDict([(0,
                          ('msg',
                           ['"Non-Std TCP Client Traffic contains "HX1|3a|" '
                            '"HX2|3a|" "HX3|3a|" "HX4|3a|" (PLUGX Variant)"'])),
                         (1, ('sid', ['7238331'])),
                         (2, ('rev', ['20170428'])),
                         (3, ('flow', ['established', 'to_server'])),
                         (4, ('content', ['"Accept|3a 20 2a 2f 2a|"'])),
                         (5, ('nocase', '')),
                         (6, ('content', ['"HX1|3a|"'])),
                         (7, ('distance', ['0'])),
                         (8, ('within', ['6'])),
                         (9, ('fast_pattern', '')),
                         (10, ('content', ['"HX2|3a|"'])),
                         (11, ('nocase', '')),
                         (12, ('distance', ['0'])),
                         (13, ('content', ['"HX3|3a|"'])),
                         (14, ('nocase', '')),
                         (15, ('distance', ['0'])),
                         (16, ('content', ['"HX4|3a|"'])),
                         (17, ('nocase', '')),
                         (18, ('distance', ['0'])),
                         (19, ('classtype', ['nonstd-tcp'])),
                         (20,
                          ('threshold',
                           ['type limit',
                            'track by_src',
                            'count 1',
                            'seconds 60'])),
                         (21, ('priority', ['X'])),
                         (22,
                          ('reference',
                           ['url',
                            'cti.cert.europa.eu/index.php/mnuthreatobject/indicatorslist/details/83/12844'])),
                         (23, ('gid', ['1']))])}
```